### PR TITLE
US-6

### DIFF
--- a/src/net/sf/memoranda/ui/AppFrame.java
+++ b/src/net/sf/memoranda/ui/AppFrame.java
@@ -687,11 +687,11 @@ public class AppFrame extends JFrame {
             else
                 doMinimize();
         }
-        else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
+        /*else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
             super.processWindowEvent(new WindowEvent(this,
                     WindowEvent.WINDOW_CLOSING));
             doMinimize();
-        }
+        }*/
         else
             super.processWindowEvent(e);
     }

--- a/src/net/sf/memoranda/ui/AppFrame.java
+++ b/src/net/sf/memoranda/ui/AppFrame.java
@@ -103,11 +103,11 @@ public class AppFrame extends JFrame {
         }
     };
 
-    public Action minimizeAction = new AbstractAction("Close the window") {
+    /*public Action minimizeAction = new AbstractAction("Close the window") {
         public void actionPerformed(ActionEvent e) {
             doMinimize();
         }
-    };
+    };*/
 
     public Action preferencesAction = new AbstractAction("Preferences") {
         public void actionPerformed(ActionEvent e) {
@@ -147,7 +147,7 @@ public class AppFrame extends JFrame {
     JMenuItem jMenuFileImportNote = new JMenuItem(importOneNoteAction);
     JMenuItem jMenuFileExportNote = new JMenuItem(
             workPanel.dailyItemsPanel.editorPanel.exportAction);
-    JMenuItem jMenuFileMin = new JMenuItem(minimizeAction);
+    //JMenuItem jMenuFileMin = new JMenuItem(minimizeAction);
 
     JMenuItem jMenuItem1 = new JMenuItem();
     JMenuItem jMenuEditUndo = new JMenuItem(editor.undoAction);
@@ -337,9 +337,9 @@ public class AppFrame extends JFrame {
         jMenuFileImportNote.setText(Local.getString("Import one note")
                 + "...");
         jMenuFilePackPrj.setText(Local.getString("Pack project") + "...");
-        jMenuFileMin.setText(Local.getString("Close the window"));
+        /*jMenuFileMin.setText(Local.getString("Close the window"));
         jMenuFileMin.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F10,
-                InputEvent.ALT_MASK));
+                InputEvent.ALT_MASK));*/
 
         jMenuEdit.setText(Local.getString("Edit"));
 
@@ -458,8 +458,8 @@ public class AppFrame extends JFrame {
         jMenuFile.addSeparator();
         jMenuFile.add(jMenuEditPref);
         jMenuFile.addSeparator();
-        jMenuFile.add(jMenuFileMin);
-        jMenuFile.addSeparator();
+        //jMenuFile.add(jMenuFileMin);
+        //jMenuFile.addSeparator();
         jMenuFile.add(jMenuFileExit);
         
         jMenuHelp.add(jMenuHelpGuide);

--- a/src/net/sf/memoranda/ui/AppFrame.java
+++ b/src/net/sf/memoranda/ui/AppFrame.java
@@ -682,10 +682,10 @@ public class AppFrame extends JFrame {
 
     protected void processWindowEvent(WindowEvent e) {
         if (e.getID() == WindowEvent.WINDOW_CLOSING) {
-            if (Configuration.get("ON_CLOSE").equals("exit"))
+            //if (Configuration.get("ON_CLOSE").equals("exit"))
                 doExit();
-            else
-                doMinimize();
+            //else
+                //doMinimize();
         }
         /*else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
             super.processWindowEvent(new WindowEvent(this,

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -57,7 +57,7 @@ public class PreferencesDialog extends JDialog {
 
 	JLabel jLabel4 = new JLabel();
 
-	JCheckBox enSystrayChB = new JCheckBox();
+	//JCheckBox enSystrayChB = new JCheckBox();
 
 	JCheckBox startMinimizedChB = new JCheckBox();
 
@@ -342,7 +342,7 @@ public class PreferencesDialog extends JDialog {
 		gbc.insets = new Insets(2, 10, 0, 15);
 		gbc.anchor = GridBagConstraints.EAST;
 		GeneralPanel.add(jLabel4, gbc);
-		enSystrayChB.setText(Local.getString("Enable system tray icon"));
+		/*enSystrayChB.setText(Local.getString("Enable system tray icon"));
 		enSystrayChB.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				enSystrayChB_actionPerformed(e);
@@ -353,7 +353,7 @@ public class PreferencesDialog extends JDialog {
 		gbc.gridy = 10;
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(enSystrayChB, gbc);
+		GeneralPanel.add(enSystrayChB, gbc);*/
 		startMinimizedChB.setText(Local.getString("Start minimized"));
 		gbc = new GridBagConstraints();
 		gbc.gridx = 1;
@@ -526,8 +526,8 @@ public class PreferencesDialog extends JDialog {
 				.equalsIgnoreCase("yes"));
 		enSplashChB.setSelected(!Configuration.get("SHOW_SPLASH").toString()
 				.equalsIgnoreCase("no"));
-		enSystrayChB.setSelected(!Configuration.get("DISABLE_SYSTRAY")
-				.toString().equalsIgnoreCase("yes"));
+		/*enSystrayChB.setSelected(!Configuration.get("DISABLE_SYSTRAY")
+				.toString().equalsIgnoreCase("yes"));*/
 		startMinimizedChB.setSelected(Configuration.get("START_MINIMIZED")
 				.toString().equalsIgnoreCase("yes"));
 		firstdow.setSelected(Configuration.get("FIRST_DAY_OF_WEEK").toString()
@@ -625,10 +625,10 @@ public class PreferencesDialog extends JDialog {
 		else
 			Configuration.put("SHOW_SPLASH", "no");
 
-		if (this.enSystrayChB.isSelected())
+		/*if (this.enSystrayChB.isSelected())
 			Configuration.put("DISABLE_SYSTRAY", "no");
 		else
-			Configuration.put("DISABLE_SYSTRAY", "yes");
+			Configuration.put("DISABLE_SYSTRAY", "yes");*/
 
 		if (this.startMinimizedChB.isSelected())
 			Configuration.put("START_MINIMIZED", "yes");
@@ -777,9 +777,9 @@ public class PreferencesDialog extends JDialog {
 		this.enableCustomLF(true);
 	}
 
-	void enSystrayChB_actionPerformed(ActionEvent e) {
+	/*void enSystrayChB_actionPerformed(ActionEvent e) {
 
-	}
+	}*/
 
 	void enSplashChB_actionPerformed(ActionEvent e) {
 

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -241,7 +241,7 @@ public class PreferencesDialog extends JDialog {
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
 		GeneralPanel.add(minHideRB, gbc);*/
-		jLabel2.setHorizontalAlignment(SwingConstants.RIGHT);
+		/*jLabel2.setHorizontalAlignment(SwingConstants.RIGHT);
 		jLabel2.setText(Local.getString("Window close action:"));
 		gbc = new GridBagConstraints();
 		gbc.gridx = 0;
@@ -276,7 +276,7 @@ public class PreferencesDialog extends JDialog {
 		gbc.gridy = 3;
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(closeHideRB, gbc);
+		GeneralPanel.add(closeHideRB, gbc);*/
 		jLabel3.setHorizontalAlignment(SwingConstants.RIGHT);
 		jLabel3.setText(Local.getString("Look and feel:"));
 		gbc = new GridBagConstraints();

--- a/src/net/sf/memoranda/ui/PreferencesDialog.java
+++ b/src/net/sf/memoranda/ui/PreferencesDialog.java
@@ -59,7 +59,7 @@ public class PreferencesDialog extends JDialog {
 
 	//JCheckBox enSystrayChB = new JCheckBox();
 
-	JCheckBox startMinimizedChB = new JCheckBox();
+	//JCheckBox startMinimizedChB = new JCheckBox();
 
 	JCheckBox enSplashChB = new JCheckBox();
 
@@ -157,13 +157,13 @@ public class PreferencesDialog extends JDialog {
 				.getString("Sound"));
 		this.setResizable(false);
 		// Build Tab1
-		jLabel1.setHorizontalAlignment(SwingConstants.RIGHT);
+		/*jLabel1.setHorizontalAlignment(SwingConstants.RIGHT);
 		jLabel1.setText(Local.getString("Window minimize action:"));
 		gbc = new GridBagConstraints();
 		gbc.gridx = 0;
 		gbc.gridy = 0;
 		gbc.insets = new Insets(10, 10, 0, 15);
-		gbc.anchor = GridBagConstraints.EAST;
+		gbc.anchor = GridBagConstraints.EAST;*/
 		enableSoundCB.setText(Local.getString("Enable sound notifications"));
 		enableSoundCB.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(ActionEvent e) {
@@ -213,7 +213,7 @@ public class PreferencesDialog extends JDialog {
 		jPanel3.add(soundFile, BorderLayout.CENTER);
 		jPanel3.add(soundFileBrowseB, BorderLayout.EAST);
 		jPanel3.add(jLabel6, BorderLayout.WEST);
-		GeneralPanel.add(jLabel1, gbc);
+		/*GeneralPanel.add(jLabel1, gbc);
 		minGroup.add(minTaskbarRB);
 		minTaskbarRB.setSelected(true);
 		minTaskbarRB.setText(Local.getString("Minimize to taskbar"));
@@ -240,7 +240,7 @@ public class PreferencesDialog extends JDialog {
 		gbc.gridy = 1;
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(minHideRB, gbc);
+		GeneralPanel.add(minHideRB, gbc);*/
 		jLabel2.setHorizontalAlignment(SwingConstants.RIGHT);
 		jLabel2.setText(Local.getString("Window close action:"));
 		gbc = new GridBagConstraints();
@@ -354,13 +354,13 @@ public class PreferencesDialog extends JDialog {
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
 		GeneralPanel.add(enSystrayChB, gbc);*/
-		startMinimizedChB.setText(Local.getString("Start minimized"));
+		/*startMinimizedChB.setText(Local.getString("Start minimized"));
 		gbc = new GridBagConstraints();
 		gbc.gridx = 1;
 		gbc.gridy = 11;
 		gbc.insets = new Insets(2, 0, 0, 10);
 		gbc.anchor = GridBagConstraints.WEST;
-		GeneralPanel.add(startMinimizedChB, gbc);
+		GeneralPanel.add(startMinimizedChB, gbc);*/
 		enSplashChB.setText(Local.getString("Show splash screen"));
 		enSplashChB.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(ActionEvent e) {
@@ -528,8 +528,8 @@ public class PreferencesDialog extends JDialog {
 				.equalsIgnoreCase("no"));
 		/*enSystrayChB.setSelected(!Configuration.get("DISABLE_SYSTRAY")
 				.toString().equalsIgnoreCase("yes"));*/
-		startMinimizedChB.setSelected(Configuration.get("START_MINIMIZED")
-				.toString().equalsIgnoreCase("yes"));
+		/*startMinimizedChB.setSelected(Configuration.get("START_MINIMIZED")
+				.toString().equalsIgnoreCase("yes"));*/
 		firstdow.setSelected(Configuration.get("FIRST_DAY_OF_WEEK").toString()
 				.equalsIgnoreCase("mon"));
 
@@ -630,10 +630,10 @@ public class PreferencesDialog extends JDialog {
 		else
 			Configuration.put("DISABLE_SYSTRAY", "yes");*/
 
-		if (this.startMinimizedChB.isSelected())
+		/*if (this.startMinimizedChB.isSelected())
 			Configuration.put("START_MINIMIZED", "yes");
 		else
-			Configuration.put("START_MINIMIZED", "no");
+			Configuration.put("START_MINIMIZED", "no");*/
 
 		if (this.askConfirmChB.isSelected())
 			Configuration.put("ASK_ON_EXIT", "yes");

--- a/src/net/sf/memoranda/util/resources/memoranda.default.properties
+++ b/src/net/sf/memoranda/util/resources/memoranda.default.properties
@@ -8,7 +8,7 @@ DISABLE_L10N = no
 LOOK_AND_FEEL = default
 
 # Disable system tray feature (yes | no*)
-DISABLE_SYSTRAY = no
+DISABLE_SYSTRAY = yes
 
 # Action on window closing (exit | minimize*)
 ON_CLOSE = minimize

--- a/src/net/sf/memoranda/util/resources/memoranda.default.properties
+++ b/src/net/sf/memoranda/util/resources/memoranda.default.properties
@@ -11,7 +11,7 @@ LOOK_AND_FEEL = default
 DISABLE_SYSTRAY = yes
 
 # Action on window closing (exit | minimize*)
-ON_CLOSE = minimize
+ON_CLOSE = exit
 
 # Action on window minimizing (normal*)
 ON_MINIMIZE = normal


### PR DESCRIPTION
I edited default preferences so that program exits on close instead of minimizing and also removed/commented out all references to system tray because it is not working at the moment (I believe the original dev team used systray4j library but I don't see any references to it in this codebase).  

I restored default/normal functionality to close and minimize window buttons and removed options in preferences to change these options.  Also removed the "Close the window" menu option (under File), because it was redundant and did same thing as hiding the window (if the hide on close option was selected in preferences).

It is still easily possible to see the old minimized functionality (for testing) by changing the "memoranda.properties" file in users home directory/.memoranda (START_MINIMIZED = yes).

It can also be tested by using -m flag in arguments when running the program.

I commented out code instead of removing it in case it is decided this functionality would be useful in the future it could be un-commented to re-implement instead of copy/pasting in correct places.